### PR TITLE
Add navigation alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ alias ..='cd ..'
 alias ...='cd ../..'
 alias ....='cd ../../..'
 alias .....='cd ../../../..'
+alias ll='ls -alF'
 ```
 
 #### Browsers ####


### PR DESCRIPTION
Hi!
Personally I really like "ll" (default ubuntu alias for ls -alF) for listing directory.
What do you think?
