### PR TITLE
Add 'git delete merged branches' alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ alias gco='git checkout'
 alias gcob='git checkout -b'
 alias gcm='git commit -m'
 alias gamend='git commit -a --amend'
+alias gdeletemerged='git branch --merged | egrep -v "(^\*|master|dev)" | xargs git branch -d'
 ```
 
 #### Server ####


### PR DESCRIPTION
Goal: Add alias to delete local fully merged files.

Git bash output example:
```
~/WebstormProjects/example on  PT-122 [$] via ⬢  
➜ git branch --merged | egrep -v "(^\*|master|dev)" | xargs git branch -d
Deleted branch PT-107 (was 5f33f9c).
Deleted branch PT-110 (was c3234e0).
Deleted branch PT-118 (was 9dcbcc5).
Deleted branch PT-130 (was 85f3c91).
Deleted branch PT-132 (was b3d9742).
Deleted branch PT-132-additional-changes (was 77bd1f6).
Deleted branch PT-139 (was a4c9ee8).
Deleted branch PT-143 (was 33195d5).
Deleted branch PT-57 (was 828c048).
Deleted branch PT-89 (was 7278406).
Deleted branch _ (was c3234e0).
```